### PR TITLE
Create per-platform release zips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,13 @@ jobs:
     runs-on: ${{ matrix.os }} 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        include:
+          - os: ubuntu-latest
+            asset_name: linux.zip
+          - os: macos-latest
+            asset_name: macos.zip
+          - os: windows-latest
+            asset_name: windows.zip
     environment: build
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
@@ -35,12 +41,12 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Build
       run: |
-        pyinstaller src/main.py --onefile
+        pyinstaller src/main.py --onedir
+        python -c "import shutil; shutil.make_archive('dist/main', 'zip', 'dist/main')"
     - name: upload executable to github tag
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.OAUTH_TOKEN }}
-        file: ${{github.workspace}}/dist/main*
+        file: ${{ github.workspace }}/dist/main.zip
+        asset_name: ${{ matrix.asset_name }}
         tag: ${{ github.ref }}
-        overwrite: true
-        file_glob: true


### PR DESCRIPTION
This creates zip files containing the build artifacts for each of the three supported platforms. Example published output from my feature fork: https://github.com/aleun/serial-monitor-cli/releases/tag/v0.0.1-fake7

A follow-on PR against https://github.com/microsoft/vscode-arduino is necessary to consume these artifacts.