### PR TITLE
Use 32-bit Python for Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8 x86
       uses: actions/setup-python@v2
-      if: ${{ matrix.os == 'windows-latest' }}
+      if: matrix.os == 'windows-latest'
       with:
         python-version: 3.8
         architecture: 'x86'
     - name: Set up Python 3.8 x64
       uses: actions/setup-python@v2
-      if: ${{ matrix.os == 'ubuntu-latest' }} || ${{ matrix.os == 'macos-latest' }}
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
       with:
         python-version: 3.8
         architecture: 'x64'


### PR DESCRIPTION
Conditionals already evaluate as expressions, so the extra braces were confusing the runner and causing it to install Python twice for Windows builds. [Build artifact](https://github.com/microsoft/serial-monitor-cli/actions/runs/1720048297) was validated with an Arduino on a 32-bit Windows VM.

Addresses https://github.com/microsoft/vscode-arduino/issues/1334