### PR TITLE
Add option for printing timestamp before each line

### DIFF
--- a/src/dataHandler.py
+++ b/src/dataHandler.py
@@ -67,7 +67,7 @@ def print_to_console_json(data: bytes or str, timestamp_format=""):
         data = data.decode('utf-8').strip()
     if data:
         timestamp = datetime.now().strftime(timestamp_format)
-        output = {'payload': f"{timestamp}{data}"}
+        output = {'payload': data, 'timestamp': timestamp}
         json_output = json.dumps(output)
         encoded_output = json_output.encode('utf-8')
         stdout.buffer.write(encoded_output)

--- a/src/dataHandler.py
+++ b/src/dataHandler.py
@@ -2,6 +2,7 @@ import json
 from queue import Queue
 from serialMonitorCtrl import SerialMonitor
 from sys import stdin, stdout
+from datetime import datetime
 
 """
 Read data written to console
@@ -42,10 +43,12 @@ Write data to console
 """
 
 
-def print_to_console(data: bytes or str):
+def print_to_console(data: bytes or str, timestamp=""):
     if type(data) is str:
         data = data.encode('utf-8')
     if data:
+        timestamp = datetime.now().strftime(timestamp).encode('utf-8')
+        stdout.buffer.write(timestamp)
         stdout.buffer.write(data)
         stdout.buffer.flush()
     elif data is None:
@@ -59,11 +62,12 @@ Write data to console in json format
 """
 
 
-def print_to_console_json(data: bytes or str):
+def print_to_console_json(data: bytes or str, timestamp=""):
     if type(data) is bytes:
         data = data.decode('utf-8').strip()
     if data:
-        output = {'payload': data}
+        timestamp = datetime.now().strftime(timestamp)
+        output = {'payload': data, 'timestamp': timestamp}
         json_output = json.dumps(output)
         encoded_output = json_output.encode('utf-8')
         stdout.buffer.write(encoded_output)
@@ -83,7 +87,8 @@ Read data from serial service
 def read_from_device(ser: SerialMonitor, json=False):
     while ser.isOpen():
         line = ser.read()
+        timestamp = ser.get_timestamp_format()
         if json:
-            print_to_console_json(line)
+            print_to_console_json(line, timestamp)
         else:
-            print_to_console(line)
+            print_to_console(line, timestamp)

--- a/src/dataHandler.py
+++ b/src/dataHandler.py
@@ -43,11 +43,11 @@ Write data to console
 """
 
 
-def print_to_console(data: bytes or str, timestamp=""):
+def print_to_console(data: bytes or str, timestamp_format=""):
     if type(data) is str:
         data = data.encode('utf-8')
     if data:
-        timestamp = datetime.now().strftime(timestamp).encode('utf-8')
+        timestamp = datetime.now().strftime(timestamp_format).encode('utf-8')
         stdout.buffer.write(timestamp)
         stdout.buffer.write(data)
         stdout.buffer.flush()
@@ -62,11 +62,11 @@ Write data to console in json format
 """
 
 
-def print_to_console_json(data: bytes or str, timestamp=""):
+def print_to_console_json(data: bytes or str, timestamp_format=""):
     if type(data) is bytes:
         data = data.decode('utf-8').strip()
     if data:
-        timestamp = datetime.now().strftime(timestamp)
+        timestamp = datetime.now().strftime(timestamp_format)
         output = {'payload': f"{timestamp}{data}"}
         json_output = json.dumps(output)
         encoded_output = json_output.encode('utf-8')
@@ -87,8 +87,8 @@ Read data from serial service
 def read_from_device(ser: SerialMonitor, json=False):
     while ser.isOpen():
         line = ser.read()
-        timestamp = ser.get_timestamp_format()
+        timestamp_format = ser.get_timestamp_format()
         if json:
-            print_to_console_json(line, timestamp)
+            print_to_console_json(line, timestamp_format)
         else:
-            print_to_console(line, timestamp)
+            print_to_console(line, timestamp_format)

--- a/src/dataHandler.py
+++ b/src/dataHandler.py
@@ -67,7 +67,7 @@ def print_to_console_json(data: bytes or str, timestamp=""):
         data = data.decode('utf-8').strip()
     if data:
         timestamp = datetime.now().strftime(timestamp)
-        output = {'payload': data, 'timestamp': timestamp}
+        output = {'payload': f"{timestamp}{data}"}
         json_output = json.dumps(output)
         encoded_output = json_output.encode('utf-8')
         stdout.buffer.write(encoded_output)

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,10 @@ ser_parser.add_argument('-e',
                             both [crnl], or none [none]')
 ser_parser.add_argument('-j', '--json', action='store_true',
                         help='Set input and output to json mode')
+ser_parser.add_argument('-t', '--timestamp', type=str,
+                        metavar='"%H:%M:%S.%f -> "', default='',
+                        help='Format of timestamp added before each line.\
+                        List of all possible formats: https://strftime.org')
 
 args = parser.parse_args()
 
@@ -67,7 +71,8 @@ elif args.func == 'open':
                                       input_payload_queue,
                                       args.eol,
                                       args.rtscts,
-                                      args.dsrdtr)
+                                      args.dsrdtr,
+                                      args.timestamp)
     invoker = CommandInvoker(device_connection)
     invoker.registerCommand('rtsOn', rtsOn(device_connection))
     invoker.registerCommand('rtsOff', rtsOff(device_connection))

--- a/src/serialMonitorCtrl.py
+++ b/src/serialMonitorCtrl.py
@@ -19,7 +19,7 @@ class SerialMonitor:
                  eol,
                  rts=False,
                  dtr=True,
-                 timestamp=''):
+                 timestamp_format=''):
         self._port = port
         self._baud = baud
         self._rts = rts
@@ -27,7 +27,7 @@ class SerialMonitor:
         self._input_payload_queue = input_payload_queue
         self._commands = None
         self._endOfLine = line_endings[eol]
-        self._timestamp = timestamp
+        self._timestamp_format = timestamp_format
 
     """
     Initialize and open new serial port
@@ -102,7 +102,7 @@ class SerialMonitor:
     @return: timestamp format
     """
     def get_timestamp_format(self) -> str:
-        return self._timestamp
+        return self._timestamp_format
 
     """
     Creates list of available serial ports and devices

--- a/src/serialMonitorCtrl.py
+++ b/src/serialMonitorCtrl.py
@@ -18,7 +18,8 @@ class SerialMonitor:
                  input_payload_queue,
                  eol,
                  rts=False,
-                 dtr=True):
+                 dtr=True,
+                 timestamp=''):
         self._port = port
         self._baud = baud
         self._rts = rts
@@ -26,6 +27,7 @@ class SerialMonitor:
         self._input_payload_queue = input_payload_queue
         self._commands = None
         self._endOfLine = line_endings[eol]
+        self._timestamp = timestamp
 
     """
     Initialize and open new serial port
@@ -93,6 +95,14 @@ class SerialMonitor:
     """
     def setDtr(self, state: bool) -> None:
         self._serial.dtr = state
+
+    """
+    Returns format of timestamp added before each line
+
+    @return: timestamp format
+    """
+    def get_timestamp_format(self) -> str:
+        return self._timestamp
 
     """
     Creates list of available serial ports and devices


### PR DESCRIPTION
Now you can print timestamp before each line using `-t` or `--timestamp` argument.
You can find list of all available placeholders here: https://strftime.org.

---

Example (using Arduino UNO with example code from [README.md](https://github.com/microsoft/serial-monitor-cli#dev-dependecies)):
```console
❯ python src/main.py open -b 9600 /dev/cu.usbmodemFA131 -t "%H:%M:%S.%f -> "
16:25:51.907789 -> 0
16:25:52.907266 -> 1
16:25:53.906641 -> 2
16:25:54.910040 -> 3
16:25:55.909700 -> 4
16:25:56.909301 -> 5
...
```

With JSON option enabled it looks like this:
```console
❯ python3 src/main.py open -b 9600 /dev/cu.usbmodemFA131 -t "%H:%M:%S.%f -> " -j
{"payload": "09:56:32.578663 -> 0"}{"payload": "09:56:33.578014 -> 1"}{"payload": "09:56:34.581603 -> 2"}{"payload": "09:56:35.580899 -> 3"}{"payload": "09:56:36.580450 -> 4"}{"payload": "09:56:37.579972 -> 5"}
...
```
---

More people requested this feature in [vscode-arduino](https://github.com/microsoft/vscode-arduino):
- https://github.com/microsoft/vscode-arduino/issues/936
- https://github.com/microsoft/vscode-arduino/issues/1088
- https://github.com/microsoft/vscode-arduino/issues/1214

I also opened pull request in [vscode-arduino](https://github.com/microsoft/vscode-arduino) for implementing this feature in VSCode extension...

---

@benmcmorran or @gcampbell-msft or @adiazulay, please, could you review?