### PR TITLE
Don't strip whitespace when sending data in JSON

### DIFF
--- a/src/dataHandler.py
+++ b/src/dataHandler.py
@@ -61,7 +61,7 @@ Write data to console in json format
 
 def print_to_console_json(data: bytes or str):
     if type(data) is bytes:
-        data = data.decode('utf-8').strip()
+        data = data.decode('utf-8')
     if data:
         output = {'payload': data}
         json_output = json.dumps(output)


### PR DESCRIPTION
We shouldn't strip whitespace from `payload` when sending data in JSON.

---

Relevant issue from [vscode-arduino](https://github.com/microsoft/vscode-arduino):
- https://github.com/microsoft/vscode-arduino/issues/1362

I also opened pull request in [vscode-arduino](https://github.com/microsoft/vscode-arduino) for implementing this feature in VSCode extension...

---

@benmcmorran or @gcampbell-msft or @adiazulay, please, could you review?